### PR TITLE
Add release script to automate version updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,7 @@ test:
 	cargo test --verbose
 	cargo clippy --all-targets --all-features
 	cargo fmt --all --check
+
+.PHONY: release
+release:
+	@./scripts/release.sh $(VERSION)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+TAG=${1:-}
+
+if [[ -z "$TAG" ]]; then
+  echo "Usage: $0 <tag>"
+  echo "Example: $0 v0.2.1"
+  exit 1
+fi
+
+# Validate tag format (vx.y.z)
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Tag must be in format vx.y.z (e.g., v0.2.1)"
+  exit 1
+fi
+
+# Extract version from tag (remove 'v' prefix)
+VERSION="${TAG#v}"
+
+echo "Releasing ${TAG}..."
+
+# Update version in Cargo.toml
+sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+
+# Update Cargo.lock
+cargo generate-lockfile
+
+# Commit changes
+git add Cargo.toml Cargo.lock
+git commit -m "chore: release ${TAG}"
+
+# Create and push tag
+git tag "${TAG}"
+git push origin main
+git push origin "${TAG}"
+
+echo "Released ${TAG} successfully!"


### PR DESCRIPTION
## Summary

- Add `scripts/release.sh` to automate the release process
- Add `release` target to Makefile

## Changes

The release script:
1. Validates tag format (`vx.y.z`)
2. Updates version in `Cargo.toml`
3. Regenerates `Cargo.lock`
4. Commits changes with message `chore: release <tag>`
5. Creates and pushes the tag

## Usage

```bash
make release VERSION=v0.2.1
```

## Issue
- Closes https://github.com/muleyuck/edio/issues/1