### PR TITLE
Fix release script sed command for portability and precision

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,15 +4,15 @@ set -euo pipefail
 TAG=${1:-}
 
 if [[ -z "$TAG" ]]; then
-  echo "Usage: $0 <tag>"
-  echo "Example: $0 v0.2.1"
-  exit 1
+    echo "Usage: $0 <tag>"
+    echo "Example: $0 v0.2.1"
+    exit 1
 fi
 
 # Validate tag format (vx.y.z)
 if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "Error: Tag must be in format vx.y.z (e.g., v0.2.1)"
-  exit 1
+    echo "Error: Tag must be in format vx.y.z (e.g., v0.2.1)"
+    exit 1
 fi
 
 # Extract version from tag (remove 'v' prefix)
@@ -20,8 +20,8 @@ VERSION="${TAG#v}"
 
 echo "Releasing ${TAG}..."
 
-# Update version in Cargo.toml
-sed -i '' "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+# Update version in Cargo.toml ([package] section only)
+sed '/^\[package\]/,/^\[/{ s/^version = ".*"/version = "'"${VERSION}"'"/; }' Cargo.toml >Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
 
 # Update Cargo.lock
 cargo generate-lockfile


### PR DESCRIPTION
## Summary
Fix bugs in the release script introduced in #2:

- Replace macOS-specific `sed -i ''` with a portable temp file approach for cross-platform compatibility
- Use sed address range to target only `[package]` section, preventing unintended updates to dependency versions

## Test plan
- [x] Run `make release VERSION=v0.2.1` on macOS
- [x] Verify only `[package]` version is updated in Cargo.toml
- [x] Confirm `[dev-dependencies.cargo-husky]` version remains unchanged