### PR TITLE
add vulnerability audit workflow and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: / # Location of Cargo.lock
+    assignees:
+      - muleyuck
+    schedule:
+      interval: weekly
+      day: saturday
+      timezone: Asia/Tokyo

--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -1,0 +1,25 @@
+name: audit-check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  audit-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+      - name: Run cargo audit
+        run: cargo audit

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: test
 test:
+	cargo check --all-targets
 	cargo test --verbose
 	cargo clippy --all-targets --all-features
 	cargo fmt --all --check


### PR DESCRIPTION
## Summary
- Add `cargo audit` GitHub Actions workflow to check for known vulnerabilities in dependencies on push/PR to main
- Add Dependabot configuration for weekly Cargo dependency updates (Saturdays, JST)
- Add `cargo check --all-targets` to the Makefile `test` target

## Test

- [x] Success audit-check workflow